### PR TITLE
feat: 适配 Pixiv OAuth 回调并优化登录体验

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,36 +2,23 @@
 
 🌍 [English](README.md) | [简体中文](README.zh-CN.md)
 
-A Python automation tool using Playwright to simulate Pixiv OAuth login, capture authorization code, and exchange it for an access token.
-
-This fork is based on [piglig/pixiv-token](https://github.com/piglig/pixiv-token) and adds more robust OAuth callback capture for current Pixiv login behavior.
-Upstream credit and the original MIT license are preserved.
+A Python automation tool using Playwright to simulate Pixiv OAuth login, capture the authorization code, and exchange it for an access token.
 
 ---
 
 ## 📦 Features
 
 - ✅ Automated Pixiv login (username/password)
-- ✅ Headless mode support
-- ✅ Visible (non-headless) mode support
-- ✅ Access token & refresh token retrieval
+- ✅ Visible and headless mode support, with an interactive prompt at startup
+- ✅ Interactive credential entry (password is not echoed)
+- ✅ Multi-source authorization code capture: CDP network/navigation events, Playwright request/response/frame events, an injected page script, and a manual paste fallback in the terminal
+- ✅ Auto-detect system Chrome / Edge; fall back to bundled Playwright Chromium
+- ✅ Access token & refresh token retrieval, plus refresh from an existing `refresh_token`
 - ✅ Slow typing to reduce bot-detection friction
-
----
-
-## 🔁 Fork Changes
-
-This fork keeps the original project goal and adds practical compatibility improvements for current Pixiv login flows:
-
-- Multi-source authorization code capture via CDP, Playwright events, injected page script, and manual fallback
-- Optional system Chrome / Edge launch via auto-detection or `PIXIV_BROWSER_PATH`
-- Access token refresh from an existing `refresh_token`
-- Configurable navigation timeout, capture timeout, login input timeout, request timeout, and typing delay
-- Explicit browser cleanup and token exchange error reporting
-- Visible browser mode by default, because Pixiv may require manual verification
-- Interactive terminal prompts for username and password
-- Auto-skip security prompt pages (Passkeys / 2FA reminders)
-- Multi-selector fallback for Pixiv login form compatibility
+- ✅ Auto-skip security prompt pages (Passkeys / 2FA reminders)
+- ✅ Multi-selector fallback for Pixiv login form compatibility
+- ✅ Token exchange with HTTP timeout, status checks and clear error reporting
+- ✅ Interactive retry prompt when token exchange fails, avoiding a full re-login
 
 ---
 
@@ -40,7 +27,7 @@ This fork keeps the original project goal and adds practical compatibility impro
 ### 1. Clone the repository
 
 ```bash
-git clone https://github.com/shitianyaa/pixiv-token.git
+git clone https://github.com/piglig/pixiv-token.git
 cd pixiv-token
 ```
 
@@ -53,11 +40,7 @@ pip install -r requirements.txt
 playwright install chromium
 ```
 
-If Chrome or Edge is already installed, this fork will try to use it automatically on Windows. You can also set a custom browser executable:
-
-```powershell
-$env:PIXIV_BROWSER_PATH="C:\Program Files\Google\Chrome\Application\chrome.exe"
-```
+If Chrome or Edge is already installed, the tool will try to use it automatically on Windows; otherwise it falls back to the bundled Playwright Chromium.
 
 Sample requirements.txt:
 
@@ -73,22 +56,14 @@ playwright>=1.51.0
 ### Command line
 
 ```bash
-# Visible browser mode (default). The tool will prompt for username and password.
+# Interactive: prompts for username, password, and whether to open the browser window (Y/n, blank defaults to Y)
 python pixiv_token_fetcher.py
 
-# Or pass credentials explicitly
+# Pass credentials explicitly
 python pixiv_token_fetcher.py -u "your_email" -p "your_password"
 
-# Headless mode
+# Force headless mode (skips the browser-window prompt)
 python pixiv_token_fetcher.py --headless
-
-# Custom timeouts and typing speed
-python pixiv_token_fetcher.py \
-  --capture-timeout 90 \
-  --input-timeout 5000 \
-  --navigation-timeout 90000 \
-  --request-timeout 45 \
-  --typing-delay 0.05
 ```
 
 ### As a module
@@ -100,11 +75,6 @@ fetcher = PixivTokenFetcher(
     username="your_pixiv_email",
     password="your_pixiv_password",
     headless=False,  # Set to True to hide the browser window
-    capture_timeout=60,  # Seconds to wait for OAuth callback capture
-    input_timeout=3000,  # Milliseconds to wait for each login input selector
-    navigation_timeout=60000,  # Milliseconds to wait for login page navigation
-    request_timeout=30,  # Seconds to wait for the token HTTP request
-    typing_delay=0.08,  # Seconds between typed characters
 )
 code = fetcher.fetch_code()
 if code:
@@ -116,7 +86,7 @@ if code:
     print("Access Token:", token_info.get("access_token"))
     print("Refresh Token:", token_info.get("refresh_token"))
 
-# Later, reuse an existing refresh token to get a new access token.
+# Reuse an existing refresh token to get a new access token
 refreshed_info = fetcher.refresh_token("your_existing_refresh_token")
 print("New Access Token:", refreshed_info.get("access_token"))
 ```
@@ -125,14 +95,13 @@ print("New Access Token:", refreshed_info.get("access_token"))
 
 ## 🔧 How It Works
 
-1. **PKCE Generation** — Generates `code_verifier` and `code_challenge` for OAuth PKCE flow
-2. **Browser Launch** — Uses system Chrome / Edge when available, otherwise falls back to Playwright Chromium
+1. **PKCE Generation** — Generates `code_verifier` and `code_challenge` for the OAuth PKCE flow
+2. **Browser Launch** — Prefers system Chrome / Edge; falls back to the bundled Playwright Chromium; emits a clear install hint if neither is available
 3. **Auto Login** — Fills in email/password with slow typing to mimic human input
-4. **Code Capture** — Captures `pixiv://account/login?code=...` redirects from CDP network/navigation events, Playwright request/response/frame events, and an injected script that watches browser-side URL changes
+4. **Code Capture** — Listens for `pixiv://account/login?code=...` from multiple sources: CDP network and navigation events, Playwright request/response/frame events, and an injected script that watches `location` / `history` / clicks / DOM mutations
 5. **Security Prompt Handling** — Automatically clicks "Remind me later" / "Skip" if Pixiv shows a Passkeys/2FA setup page
 6. **Manual Fallback** — If automatic capture fails, accepts a pasted callback URL or raw authorization code from the terminal
-7. **Resource Cleanup** — Closes browser context and browser in a `finally` block even if login or capture fails
-8. **Token Exchange / Refresh** — Exchanges the authorization code for access & refresh tokens, or refreshes an existing refresh token, with HTTP timeout, status checks, and JSON validation
+7. **Token Exchange / Refresh** — Exchanges the authorization code for access & refresh tokens, or refreshes an existing refresh token, with HTTP timeout, status checks, and JSON validation
 
 ---
 
@@ -143,23 +112,20 @@ print("New Access Token:", refreshed_info.get("access_token"))
 - ❌ This is not an official Pixiv SDK. Changes to Pixiv's login page may affect functionality.
 - 🛡 Please comply with Pixiv's Terms of Service.
 - 🔁 The refresh token is long-lived. You typically only need to run this tool once.
-- ⏱ If Pixiv login is slow or requires extra verification, increase `--navigation-timeout` or `--capture-timeout`.
-- 🧩 If you import this tool from another project, configure Python `logging` in your application to control status output.
 
 ---
 
 ## 🧪 Example Output
 
 ```
-Opening Pixiv login page...
-Login URL: https://app-api.pixiv.net/web/v1/login?...
-Username input completed
-Password input completed
-Login submitted
+🚀 Opening Pixiv login page...
+📧 Username input completed
+🔒 Password input completed
+🔑 Login submitted
   Clicking 'Remind me later' to skip security prompt
-Code captured from console script: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-Access Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-Refresh Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+✅ Code captured: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+🎟️ Access Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+🔁 Refresh Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 ---
@@ -176,12 +142,7 @@ Pull Requests and Issues are welcome!
 
 ---
 
-## 🙏 Upstream
-
-Original project: [piglig/pixiv-token](https://github.com/piglig/pixiv-token)
-
----
-
 ## 📫 Contact
 
-- GitHub: [shitianyaa](https://github.com/shitianyaa)
+- GitHub: [piglig](https://github.com/piglig)
+- Email: zhu1197437384@gmail.com

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 A Python automation tool using Playwright to simulate Pixiv OAuth login, capture authorization code, and exchange it for an access token.
 
 This fork is based on [piglig/pixiv-token](https://github.com/piglig/pixiv-token) and adds more robust OAuth callback capture for current Pixiv login behavior.
+Upstream credit and the original MIT license are preserved.
 
 ---
 
@@ -13,12 +14,24 @@ This fork is based on [piglig/pixiv-token](https://github.com/piglig/pixiv-token
 - ✅ Automated Pixiv login (username/password)
 - ✅ Headless mode support
 - ✅ Visible (non-headless) mode support
-- ✅ Multi-source authorization code capture via CDP, Playwright events, injected page script, and manual fallback
-- ✅ Optional system Chrome / Edge launch via auto-detection or `PIXIV_BROWSER_PATH`
 - ✅ Access token & refresh token retrieval
-- ✅ Slow typing to bypass bot detection
-- ✅ Auto-skip security prompt pages (Passkeys / 2FA reminders)
-- ✅ Multi-selector fallback for Pixiv login form compatibility
+- ✅ Slow typing to reduce bot-detection friction
+
+---
+
+## 🔁 Fork Changes
+
+This fork keeps the original project goal and adds practical compatibility improvements for current Pixiv login flows:
+
+- Multi-source authorization code capture via CDP, Playwright events, injected page script, and manual fallback
+- Optional system Chrome / Edge launch via auto-detection or `PIXIV_BROWSER_PATH`
+- Access token refresh from an existing `refresh_token`
+- Configurable navigation timeout, capture timeout, login input timeout, request timeout, and typing delay
+- Explicit browser cleanup and token exchange error reporting
+- Visible browser mode by default, because Pixiv may require manual verification
+- Interactive terminal prompts for username and password
+- Auto-skip security prompt pages (Passkeys / 2FA reminders)
+- Multi-selector fallback for Pixiv login form compatibility
 
 ---
 
@@ -60,28 +73,52 @@ playwright>=1.51.0
 ### Command line
 
 ```bash
-# Headless mode (default)
+# Visible browser mode (default). The tool will prompt for username and password.
+python pixiv_token_fetcher.py
+
+# Or pass credentials explicitly
 python pixiv_token_fetcher.py -u "your_email" -p "your_password"
 
-# Visible browser mode
-python pixiv_token_fetcher.py -u "your_email" -p "your_password" --no-headless
+# Headless mode
+python pixiv_token_fetcher.py --headless
+
+# Custom timeouts and typing speed
+python pixiv_token_fetcher.py \
+  --capture-timeout 90 \
+  --input-timeout 5000 \
+  --navigation-timeout 90000 \
+  --request-timeout 45 \
+  --typing-delay 0.05
 ```
 
 ### As a module
 
 ```python
-from pixiv_token_fetcher import PixivTokenFetcher
+from pixiv_token_fetcher import PixivTokenError, PixivTokenFetcher
 
 fetcher = PixivTokenFetcher(
     username="your_pixiv_email",
     password="your_pixiv_password",
-    headless=True,  # Set to False to show browser window
+    headless=False,  # Set to True to hide the browser window
+    capture_timeout=60,  # Seconds to wait for OAuth callback capture
+    input_timeout=3000,  # Milliseconds to wait for each login input selector
+    navigation_timeout=60000,  # Milliseconds to wait for login page navigation
+    request_timeout=30,  # Seconds to wait for the token HTTP request
+    typing_delay=0.08,  # Seconds between typed characters
 )
 code = fetcher.fetch_code()
 if code:
-    token_info = fetcher.exchange_token(code)
+    try:
+        token_info = fetcher.exchange_token(code)
+    except PixivTokenError as exc:
+        raise RuntimeError(f"Token exchange failed: {exc}") from exc
+
     print("Access Token:", token_info.get("access_token"))
     print("Refresh Token:", token_info.get("refresh_token"))
+
+# Later, reuse an existing refresh token to get a new access token.
+refreshed_info = fetcher.refresh_token("your_existing_refresh_token")
+print("New Access Token:", refreshed_info.get("access_token"))
 ```
 
 ---
@@ -94,16 +131,20 @@ if code:
 4. **Code Capture** — Captures `pixiv://account/login?code=...` redirects from CDP network/navigation events, Playwright request/response/frame events, and an injected script that watches browser-side URL changes
 5. **Security Prompt Handling** — Automatically clicks "Remind me later" / "Skip" if Pixiv shows a Passkeys/2FA setup page
 6. **Manual Fallback** — If automatic capture fails, accepts a pasted callback URL or raw authorization code from the terminal
-7. **Token Exchange** — Exchanges the authorization code for access & refresh tokens via Pixiv OAuth API
+7. **Resource Cleanup** — Closes browser context and browser in a `finally` block even if login or capture fails
+8. **Token Exchange / Refresh** — Exchanges the authorization code for access & refresh tokens, or refreshes an existing refresh token, with HTTP timeout, status checks, and JSON validation
 
 ---
 
 ## 📌 Notes
 
 - ⚠️ Do not hardcode credentials in production environments. Use environment variables or a secrets manager.
+- 🔐 If `--username` or `--password` is omitted in an interactive terminal, the tool prompts for it. Password input is hidden.
 - ❌ This is not an official Pixiv SDK. Changes to Pixiv's login page may affect functionality.
 - 🛡 Please comply with Pixiv's Terms of Service.
 - 🔁 The refresh token is long-lived. You typically only need to run this tool once.
+- ⏱ If Pixiv login is slow or requires extra verification, increase `--navigation-timeout` or `--capture-timeout`.
+- 🧩 If you import this tool from another project, configure Python `logging` in your application to control status output.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A Python automation tool using Playwright to simulate Pixiv OAuth login, capture authorization code, and exchange it for an access token.
 
+This fork is based on [piglig/pixiv-token](https://github.com/piglig/pixiv-token) and adds more robust OAuth callback capture for current Pixiv login behavior.
+
 ---
 
 ## 📦 Features
@@ -11,7 +13,8 @@ A Python automation tool using Playwright to simulate Pixiv OAuth login, capture
 - ✅ Automated Pixiv login (username/password)
 - ✅ Headless mode support
 - ✅ Visible (non-headless) mode support
-- ✅ Console-based authorization code capture via CDP
+- ✅ Multi-source authorization code capture via CDP, Playwright events, injected page script, and manual fallback
+- ✅ Optional system Chrome / Edge launch via auto-detection or `PIXIV_BROWSER_PATH`
 - ✅ Access token & refresh token retrieval
 - ✅ Slow typing to bypass bot detection
 - ✅ Auto-skip security prompt pages (Passkeys / 2FA reminders)
@@ -24,7 +27,7 @@ A Python automation tool using Playwright to simulate Pixiv OAuth login, capture
 ### 1. Clone the repository
 
 ```bash
-git clone https://github.com/piglig/pixiv-token.git
+git clone https://github.com/shitianyaa/pixiv-token.git
 cd pixiv-token
 ```
 
@@ -35,6 +38,12 @@ Recommended Python version: `>=3.8`
 ```bash
 pip install -r requirements.txt
 playwright install chromium
+```
+
+If Chrome or Edge is already installed, this fork will try to use it automatically on Windows. You can also set a custom browser executable:
+
+```powershell
+$env:PIXIV_BROWSER_PATH="C:\Program Files\Google\Chrome\Application\chrome.exe"
 ```
 
 Sample requirements.txt:
@@ -80,11 +89,12 @@ if code:
 ## 🔧 How It Works
 
 1. **PKCE Generation** — Generates `code_verifier` and `code_challenge` for OAuth PKCE flow
-2. **Browser Launch** — Uses Chrome's native `--headless=new` mode (full browser engine without a visible window, undetectable by reCAPTCHA)
+2. **Browser Launch** — Uses system Chrome / Edge when available, otherwise falls back to Playwright Chromium
 3. **Auto Login** — Fills in email/password with slow typing to mimic human input
-4. **Code Capture** — Intercepts the `pixiv://account/login?code=...` redirect via CDP (`Network.requestWillBeSent`)
+4. **Code Capture** — Captures `pixiv://account/login?code=...` redirects from CDP network/navigation events, Playwright request/response/frame events, and an injected script that watches browser-side URL changes
 5. **Security Prompt Handling** — Automatically clicks "Remind me later" / "Skip" if Pixiv shows a Passkeys/2FA setup page
-6. **Token Exchange** — Exchanges the authorization code for access & refresh tokens via Pixiv OAuth API
+6. **Manual Fallback** — If automatic capture fails, accepts a pasted callback URL or raw authorization code from the terminal
+7. **Token Exchange** — Exchanges the authorization code for access & refresh tokens via Pixiv OAuth API
 
 ---
 
@@ -100,14 +110,15 @@ if code:
 ## 🧪 Example Output
 
 ```
-🚀 Opening Pixiv login page...
-📧 Username input completed
-🔒 Password input completed
-🔑 Login submitted
+Opening Pixiv login page...
+Login URL: https://app-api.pixiv.net/web/v1/login?...
+Username input completed
+Password input completed
+Login submitted
   Clicking 'Remind me later' to skip security prompt
-✅ Code captured: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-🎟️ Access Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-🔁 Refresh Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+Code captured from console script: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+Access Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+Refresh Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 ---
@@ -124,7 +135,12 @@ Pull Requests and Issues are welcome!
 
 ---
 
+## 🙏 Upstream
+
+Original project: [piglig/pixiv-token](https://github.com/piglig/pixiv-token)
+
+---
+
 ## 📫 Contact
 
-- GitHub: [piglig](https://github.com/piglig)
-- Email: zhu1197437384@gmail.com
+- GitHub: [shitianyaa](https://github.com/shitianyaa)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,6 +4,8 @@
 
 使用 Python + Playwright 自动模拟 Pixiv OAuth 登录流程，提取授权码，并换取 access_token。
 
+本仓库 fork 自 [piglig/pixiv-token](https://github.com/piglig/pixiv-token)，主要增强了当前 Pixiv 登录流程下的 OAuth 回调捕获稳定性。
+
 ---
 
 ## 📦 功能亮点
@@ -11,7 +13,8 @@
 - ✅ 自动化模拟 Pixiv 登录流程（用户名密码）
 - ✅ 支持无头模式
 - ✅ 支持窗口模式（非无头）
-- ✅ 通过 CDP 在控制台捕获授权码
+- ✅ 通过 CDP、Playwright 事件、页面注入脚本和手动兜底多路捕获授权码
+- ✅ 支持自动使用系统 Chrome / Edge，也可通过 `PIXIV_BROWSER_PATH` 指定浏览器
 - ✅ 获取 access_token 与 refresh_token
 - ✅ 缓慢输入模拟真人操作，绕过机器人检测
 - ✅ 自动跳过安全设置提示页面（Passkeys / 2FA 提醒）
@@ -24,7 +27,7 @@
 ### 1. 克隆项目
 
 ```bash
-git clone https://github.com/piglig/pixiv-token.git
+git clone https://github.com/shitianyaa/pixiv-token.git
 cd pixiv-token
 ```
 
@@ -35,6 +38,12 @@ cd pixiv-token
 ```bash
 pip install -r requirements.txt
 playwright install chromium
+```
+
+如果本机已经安装 Chrome 或 Edge，本 fork 会在 Windows 上自动尝试使用系统浏览器。也可以手动指定浏览器路径：
+
+```powershell
+$env:PIXIV_BROWSER_PATH="C:\Program Files\Google\Chrome\Application\chrome.exe"
 ```
 
 依赖示例：
@@ -80,11 +89,12 @@ if code:
 ## 🔧 工作原理
 
 1. **PKCE 生成** — 生成 `code_verifier` 和 `code_challenge` 用于 OAuth PKCE 流程
-2. **浏览器启动** — 使用 Chrome 原生 `--headless=new` 模式（完整浏览器引擎，无可见窗口，reCAPTCHA 无法检测）
+2. **浏览器启动** — 优先使用系统 Chrome / Edge，找不到时回退到 Playwright Chromium
 3. **自动登录** — 以缓慢输入方式填写邮箱和密码，模拟真人操作
-4. **授权码捕获** — 通过 CDP（`Network.requestWillBeSent`）拦截 `pixiv://account/login?code=...` 重定向
+4. **授权码捕获** — 从 CDP 网络/导航事件、Playwright 请求/响应/Frame 事件，以及页面注入脚本中捕获 `pixiv://account/login?code=...` 回调
 5. **安全提示处理** — 若 Pixiv 弹出 Passkeys/2FA 设置页面，自动点击"稍后提醒"/"跳过"
-6. **Token 交换** — 通过 Pixiv OAuth API 将授权码换取 access token 和 refresh token
+6. **手动兜底** — 如果自动捕获失败，可以在终端粘贴完整回调 URL 或原始授权码
+7. **Token 交换** — 通过 Pixiv OAuth API 将授权码换取 access token 和 refresh token
 
 ---
 
@@ -100,14 +110,15 @@ if code:
 ## 🧪 示例输出
 
 ```
-🚀 Opening Pixiv login page...
-📧 Username input completed
-🔒 Password input completed
-🔑 Login submitted
+Opening Pixiv login page...
+Login URL: https://app-api.pixiv.net/web/v1/login?...
+Username input completed
+Password input completed
+Login submitted
   Clicking 'Remind me later' to skip security prompt
-✅ Code captured: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-🎟️ Access Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-🔁 Refresh Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+Code captured from console script: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+Access Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+Refresh Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 ---
@@ -124,7 +135,12 @@ MIT License
 
 ---
 
+## 🙏 上游项目
+
+原项目：[piglig/pixiv-token](https://github.com/piglig/pixiv-token)
+
+---
+
 ## 📫 联系方式
 
-- GitHub: [piglig](https://github.com/piglig)
-- Email: zhu1197437384@gmail.com
+- GitHub: [shitianyaa](https://github.com/shitianyaa)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,34 +4,21 @@
 
 使用 Python + Playwright 自动模拟 Pixiv OAuth 登录流程，提取授权码，并换取 access_token。
 
-本仓库 fork 自 [piglig/pixiv-token](https://github.com/piglig/pixiv-token)，主要增强了当前 Pixiv 登录流程下的 OAuth 回调捕获稳定性。
-上游来源说明和原 MIT License 均保留。
-
 ---
 
 ## 📦 功能亮点
 
 - ✅ 自动化模拟 Pixiv 登录流程（用户名密码）
-- ✅ 支持无头模式
-- ✅ 支持窗口模式（非无头）
-- ✅ 获取 access_token 与 refresh_token
-- ✅ 缓慢输入以降低机器人检测干扰
-
----
-
-## 🔁 本 Fork 变更
-
-本 fork 保留原项目目标，并针对当前 Pixiv 登录流程补充了一些实用兼容性改动：
-
-- 通过 CDP、Playwright 事件、页面注入脚本和手动兜底多路捕获授权码
-- 支持自动使用系统 Chrome / Edge，也可通过 `PIXIV_BROWSER_PATH` 指定浏览器
-- 可使用已有 `refresh_token` 刷新 access token
-- 可配置页面导航超时、授权码捕获超时、登录输入框等待超时、请求超时和输入延迟
-- 异常路径显式清理浏览器资源，并提供明确的 token 交换错误信息
-- 默认显示浏览器窗口，方便处理 Pixiv 可能出现的人机验证
-- 支持在终端交互式输入账号和密码
-- 自动跳过安全设置提示页面（Passkeys / 2FA 提醒）
-- 多选择器兼容 Pixiv 登录表单变化
+- ✅ 支持窗口模式与无头模式，并可在启动时交互选择
+- ✅ 支持交互式输入账号密码（密码不回显）
+- ✅ 多路捕获授权码：CDP 网络/导航事件、Playwright 请求/响应/Frame 事件、页面注入脚本，自动失败时支持终端粘贴回调 URL 兜底
+- ✅ 自动检测系统 Chrome / Edge，找不到时回退到 Playwright 自带 Chromium
+- ✅ 获取 access_token 与 refresh_token，并支持用已有 refresh_token 刷新
+- ✅ 缓慢输入模拟真人操作，绕过机器人检测
+- ✅ 自动跳过安全设置提示页面（Passkeys / 2FA 提醒）
+- ✅ 多选择器兼容 Pixiv 登录表单变化
+- ✅ Token 交换带 HTTP 超时、状态码检查和明确的错误异常
+- ✅ Token 交换失败时可在终端选择重试，避免重新走完整登录流程
 
 ---
 
@@ -40,7 +27,7 @@
 ### 1. 克隆项目
 
 ```bash
-git clone https://github.com/shitianyaa/pixiv-token.git
+git clone https://github.com/piglig/pixiv-token.git
 cd pixiv-token
 ```
 
@@ -53,11 +40,7 @@ pip install -r requirements.txt
 playwright install chromium
 ```
 
-如果本机已经安装 Chrome 或 Edge，本 fork 会在 Windows 上自动尝试使用系统浏览器。也可以手动指定浏览器路径：
-
-```powershell
-$env:PIXIV_BROWSER_PATH="C:\Program Files\Google\Chrome\Application\chrome.exe"
-```
+如果本机已经安装 Chrome 或 Edge，会在 Windows 上自动尝试使用系统浏览器；若没有系统浏览器，则会使用 Playwright 自带的 Chromium。
 
 依赖示例：
 
@@ -73,22 +56,14 @@ playwright>=1.51.0
 ### 命令行方式
 
 ```bash
-# 显示浏览器窗口（默认），工具会提示输入账号和密码
+# 交互模式：依次提示输入账号、密码、是否打开浏览器窗口（Y/n，留空默认打开）
 python pixiv_token_fetcher.py
 
-# 也可以显式传入账号密码
+# 显式传入账号密码
 python pixiv_token_fetcher.py -u "你的邮箱" -p "你的密码"
 
-# 无头模式
+# 强制无头模式（跳过交互询问）
 python pixiv_token_fetcher.py --headless
-
-# 自定义超时和输入速度
-python pixiv_token_fetcher.py \
-  --capture-timeout 90 \
-  --input-timeout 5000 \
-  --navigation-timeout 90000 \
-  --request-timeout 45 \
-  --typing-delay 0.05
 ```
 
 ### 作为模块调用
@@ -100,11 +75,6 @@ fetcher = PixivTokenFetcher(
     username="你的Pixiv账号",
     password="你的Pixiv密码",
     headless=False,  # 设为 True 隐藏浏览器窗口
-    capture_timeout=60,  # 等待 OAuth 回调捕获的秒数
-    input_timeout=3000,  # 每个登录输入框选择器的等待毫秒数
-    navigation_timeout=60000,  # 登录页导航等待毫秒数
-    request_timeout=30,  # token HTTP 请求等待秒数
-    typing_delay=0.08,  # 每个字符之间的输入间隔秒数
 )
 code = fetcher.fetch_code()
 if code:
@@ -116,7 +86,7 @@ if code:
     print("Access Token:", token_info.get("access_token"))
     print("Refresh Token:", token_info.get("refresh_token"))
 
-# 后续可以复用已有 refresh token 获取新的 access token。
+# 后续可以复用已有 refresh token 获取新的 access token
 refreshed_info = fetcher.refresh_token("已有的_refresh_token")
 print("New Access Token:", refreshed_info.get("access_token"))
 ```
@@ -126,13 +96,12 @@ print("New Access Token:", refreshed_info.get("access_token"))
 ## 🔧 工作原理
 
 1. **PKCE 生成** — 生成 `code_verifier` 和 `code_challenge` 用于 OAuth PKCE 流程
-2. **浏览器启动** — 优先使用系统 Chrome / Edge，找不到时回退到 Playwright Chromium
+2. **浏览器启动** — 优先使用系统 Chrome / Edge，找不到时回退到 Playwright 自带 Chromium；两者都没有时给出明确安装提示
 3. **自动登录** — 以缓慢输入方式填写邮箱和密码，模拟真人操作
-4. **授权码捕获** — 从 CDP 网络/导航事件、Playwright 请求/响应/Frame 事件，以及页面注入脚本中捕获 `pixiv://account/login?code=...` 回调
+4. **授权码捕获** — 多路监听 `pixiv://account/login?code=...` 回调：CDP 网络与导航事件、Playwright 请求/响应/Frame 事件，以及一段注入到页面的 JS 脚本（监控 `location` / `history` / 点击 / DOM 变化）
 5. **安全提示处理** — 若 Pixiv 弹出 Passkeys/2FA 设置页面，自动点击"稍后提醒"/"跳过"
 6. **手动兜底** — 如果自动捕获失败，可以在终端粘贴完整回调 URL 或原始授权码
-7. **资源清理** — 即使登录或捕获过程失败，也会在 `finally` 中关闭浏览器上下文和浏览器
-8. **Token 交换 / 刷新** — 通过 Pixiv OAuth API 将授权码换取 access token 和 refresh token，或使用已有 refresh token 刷新 access token，并带有 HTTP 超时、状态码检查和 JSON 校验
+7. **Token 交换 / 刷新** — 通过 Pixiv OAuth API 将授权码换取 access token 和 refresh token，或使用已有 refresh token 刷新 access token，并带有 HTTP 超时、状态码检查和 JSON 校验
 
 ---
 
@@ -143,23 +112,20 @@ print("New Access Token:", refreshed_info.get("access_token"))
 - ❌ 本项目非 Pixiv 官方 SDK，Pixiv 页面结构变化可能影响运行。
 - 🛡 使用时请遵守 Pixiv 的服务条款。
 - 🔁 Refresh token 有效期很长，通常只需运行一次即可。
-- ⏱ 如果 Pixiv 登录较慢或需要额外验证，可以增大 `--navigation-timeout` 或 `--capture-timeout`。
-- 🧩 如果在其他项目中导入本工具，可以在你的应用中配置 Python `logging` 来控制状态输出。
 
 ---
 
 ## 🧪 示例输出
 
 ```
-Opening Pixiv login page...
-Login URL: https://app-api.pixiv.net/web/v1/login?...
-Username input completed
-Password input completed
-Login submitted
+🚀 Opening Pixiv login page...
+📧 Username input completed
+🔒 Password input completed
+🔑 Login submitted
   Clicking 'Remind me later' to skip security prompt
-Code captured from console script: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-Access Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-Refresh Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+✅ Code captured: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+🎟️ Access Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+🔁 Refresh Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 ---
@@ -176,12 +142,7 @@ MIT License
 
 ---
 
-## 🙏 上游项目
-
-原项目：[piglig/pixiv-token](https://github.com/piglig/pixiv-token)
-
----
-
 ## 📫 联系方式
 
-- GitHub: [shitianyaa](https://github.com/shitianyaa)
+- GitHub: [piglig](https://github.com/piglig)
+- Email: zhu1197437384@gmail.com

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,6 +5,7 @@
 使用 Python + Playwright 自动模拟 Pixiv OAuth 登录流程，提取授权码，并换取 access_token。
 
 本仓库 fork 自 [piglig/pixiv-token](https://github.com/piglig/pixiv-token)，主要增强了当前 Pixiv 登录流程下的 OAuth 回调捕获稳定性。
+上游来源说明和原 MIT License 均保留。
 
 ---
 
@@ -13,12 +14,24 @@
 - ✅ 自动化模拟 Pixiv 登录流程（用户名密码）
 - ✅ 支持无头模式
 - ✅ 支持窗口模式（非无头）
-- ✅ 通过 CDP、Playwright 事件、页面注入脚本和手动兜底多路捕获授权码
-- ✅ 支持自动使用系统 Chrome / Edge，也可通过 `PIXIV_BROWSER_PATH` 指定浏览器
 - ✅ 获取 access_token 与 refresh_token
-- ✅ 缓慢输入模拟真人操作，绕过机器人检测
-- ✅ 自动跳过安全设置提示页面（Passkeys / 2FA 提醒）
-- ✅ 多选择器兼容 Pixiv 登录表单变化
+- ✅ 缓慢输入以降低机器人检测干扰
+
+---
+
+## 🔁 本 Fork 变更
+
+本 fork 保留原项目目标，并针对当前 Pixiv 登录流程补充了一些实用兼容性改动：
+
+- 通过 CDP、Playwright 事件、页面注入脚本和手动兜底多路捕获授权码
+- 支持自动使用系统 Chrome / Edge，也可通过 `PIXIV_BROWSER_PATH` 指定浏览器
+- 可使用已有 `refresh_token` 刷新 access token
+- 可配置页面导航超时、授权码捕获超时、登录输入框等待超时、请求超时和输入延迟
+- 异常路径显式清理浏览器资源，并提供明确的 token 交换错误信息
+- 默认显示浏览器窗口，方便处理 Pixiv 可能出现的人机验证
+- 支持在终端交互式输入账号和密码
+- 自动跳过安全设置提示页面（Passkeys / 2FA 提醒）
+- 多选择器兼容 Pixiv 登录表单变化
 
 ---
 
@@ -60,28 +73,52 @@ playwright>=1.51.0
 ### 命令行方式
 
 ```bash
-# 无头模式（默认）
+# 显示浏览器窗口（默认），工具会提示输入账号和密码
+python pixiv_token_fetcher.py
+
+# 也可以显式传入账号密码
 python pixiv_token_fetcher.py -u "你的邮箱" -p "你的密码"
 
-# 显示浏览器窗口
-python pixiv_token_fetcher.py -u "你的邮箱" -p "你的密码" --no-headless
+# 无头模式
+python pixiv_token_fetcher.py --headless
+
+# 自定义超时和输入速度
+python pixiv_token_fetcher.py \
+  --capture-timeout 90 \
+  --input-timeout 5000 \
+  --navigation-timeout 90000 \
+  --request-timeout 45 \
+  --typing-delay 0.05
 ```
 
 ### 作为模块调用
 
 ```python
-from pixiv_token_fetcher import PixivTokenFetcher
+from pixiv_token_fetcher import PixivTokenError, PixivTokenFetcher
 
 fetcher = PixivTokenFetcher(
     username="你的Pixiv账号",
     password="你的Pixiv密码",
-    headless=True,  # 设为 False 显示浏览器窗口
+    headless=False,  # 设为 True 隐藏浏览器窗口
+    capture_timeout=60,  # 等待 OAuth 回调捕获的秒数
+    input_timeout=3000,  # 每个登录输入框选择器的等待毫秒数
+    navigation_timeout=60000,  # 登录页导航等待毫秒数
+    request_timeout=30,  # token HTTP 请求等待秒数
+    typing_delay=0.08,  # 每个字符之间的输入间隔秒数
 )
 code = fetcher.fetch_code()
 if code:
-    token_info = fetcher.exchange_token(code)
+    try:
+        token_info = fetcher.exchange_token(code)
+    except PixivTokenError as exc:
+        raise RuntimeError(f"Token 交换失败：{exc}") from exc
+
     print("Access Token:", token_info.get("access_token"))
     print("Refresh Token:", token_info.get("refresh_token"))
+
+# 后续可以复用已有 refresh token 获取新的 access token。
+refreshed_info = fetcher.refresh_token("已有的_refresh_token")
+print("New Access Token:", refreshed_info.get("access_token"))
 ```
 
 ---
@@ -94,16 +131,20 @@ if code:
 4. **授权码捕获** — 从 CDP 网络/导航事件、Playwright 请求/响应/Frame 事件，以及页面注入脚本中捕获 `pixiv://account/login?code=...` 回调
 5. **安全提示处理** — 若 Pixiv 弹出 Passkeys/2FA 设置页面，自动点击"稍后提醒"/"跳过"
 6. **手动兜底** — 如果自动捕获失败，可以在终端粘贴完整回调 URL 或原始授权码
-7. **Token 交换** — 通过 Pixiv OAuth API 将授权码换取 access token 和 refresh token
+7. **资源清理** — 即使登录或捕获过程失败，也会在 `finally` 中关闭浏览器上下文和浏览器
+8. **Token 交换 / 刷新** — 通过 Pixiv OAuth API 将授权码换取 access token 和 refresh token，或使用已有 refresh token 刷新 access token，并带有 HTTP 超时、状态码检查和 JSON 校验
 
 ---
 
 ## 📌 注意事项
 
 - ⚠️ 请勿在生产环境中硬编码账号密码，建议使用环境变量或密钥管理工具。
+- 🔐 如果在交互式终端中省略 `--username` 或 `--password`，工具会提示输入；密码输入不会回显。
 - ❌ 本项目非 Pixiv 官方 SDK，Pixiv 页面结构变化可能影响运行。
 - 🛡 使用时请遵守 Pixiv 的服务条款。
 - 🔁 Refresh token 有效期很长，通常只需运行一次即可。
+- ⏱ 如果 Pixiv 登录较慢或需要额外验证，可以增大 `--navigation-timeout` 或 `--capture-timeout`。
+- 🧩 如果在其他项目中导入本工具，可以在你的应用中配置 Python `logging` 来控制状态输出。
 
 ---
 

--- a/pixiv_token_fetcher.py
+++ b/pixiv_token_fetcher.py
@@ -1,13 +1,11 @@
 import base64
 import hashlib
-import logging
 import os
 import secrets
 import sys
 import requests
 import time
 import re
-from typing import Any, Dict, Optional
 from urllib.parse import unquote
 from playwright.sync_api import sync_playwright, TimeoutError
 
@@ -24,13 +22,6 @@ CALLBACK_URL_PREFIX = "pixiv://account/login"
 CONSOLE_CODE_PREFIX = "[PIXIV-CODE]"
 CONSOLE_CALLBACK_PREFIX = "[PIXIV-CALLBACK]"
 AUTH_CODE_PATTERN = re.compile(r"(?:^|[?&])code=([^&#\s\"'<>)]*)")
-DEFAULT_CAPTURE_TIMEOUT = 60
-DEFAULT_INPUT_TIMEOUT = 3000
-DEFAULT_NAVIGATION_TIMEOUT = 60000
-DEFAULT_REQUEST_TIMEOUT = 30
-DEFAULT_TYPING_DELAY = 0.08
-
-logger = logging.getLogger(__name__)
 
 EMAIL_SELECTORS = [
     "input[autocomplete^='username']",
@@ -56,36 +47,10 @@ class PixivTokenError(RuntimeError):
 
 
 class PixivTokenFetcher:
-    def __init__(
-        self,
-        username: str,
-        password: str,
-        headless: bool = False,
-        capture_timeout: int = DEFAULT_CAPTURE_TIMEOUT,
-        input_timeout: int = DEFAULT_INPUT_TIMEOUT,
-        navigation_timeout: int = DEFAULT_NAVIGATION_TIMEOUT,
-        request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
-        typing_delay: float = DEFAULT_TYPING_DELAY,
-    ):
-        if capture_timeout <= 0:
-            raise ValueError("capture_timeout must be greater than 0")
-        if input_timeout <= 0:
-            raise ValueError("input_timeout must be greater than 0")
-        if navigation_timeout <= 0:
-            raise ValueError("navigation_timeout must be greater than 0")
-        if request_timeout <= 0:
-            raise ValueError("request_timeout must be greater than 0")
-        if typing_delay < 0:
-            raise ValueError("typing_delay must be greater than or equal to 0")
-
+    def __init__(self, username, password, headless=False):
         self.headless = headless
         self.username = username
         self.password = password
-        self.capture_timeout = capture_timeout
-        self.input_timeout = input_timeout
-        self.navigation_timeout = navigation_timeout
-        self.request_timeout = request_timeout
-        self.typing_delay = typing_delay
         self.code_verifier = secrets.token_urlsafe(64)
         self.code_challenge = base64.urlsafe_b64encode(
             hashlib.sha256(self.code_verifier.encode()).digest()
@@ -94,14 +59,19 @@ class PixivTokenFetcher:
     def _launch_args(self):
         return ["--disable-blink-features=AutomationControlled"]
 
-    def _browser_executable_path(self):
-        configured_path = os.getenv("PIXIV_BROWSER_PATH")
-        if configured_path and os.path.exists(configured_path):
-            return configured_path
-
+    def _browser_executable_path(self, playwright=None):
         for browser_path in DEFAULT_BROWSER_PATHS:
             if os.path.exists(browser_path):
                 return browser_path
+
+        if playwright is not None:
+            try:
+                bundled_path = playwright.chromium.executable_path
+            except Exception:
+                bundled_path = None
+            if bundled_path and os.path.exists(bundled_path):
+                return bundled_path
+            print("⚠️ No browser found. Run: python -m playwright install chromium")
 
         return None
 
@@ -112,7 +82,7 @@ class PixivTokenFetcher:
             "code_challenge_method=S256&client=pixiv-android"
         )
 
-    def _extract_code(self, value: str) -> Optional[str]:
+    def _extract_code(self, value):
         if not value:
             return None
 
@@ -132,7 +102,7 @@ class PixivTokenFetcher:
 
         return None
 
-    def _read_manual_code(self) -> Optional[str]:
+    def _read_manual_code(self):
         if not sys.stdin.isatty():
             return None
 
@@ -151,7 +121,7 @@ class PixivTokenFetcher:
         if re.fullmatch(r"[A-Za-z0-9_-]+", manual_value):
             return manual_value
 
-        print("No authorization code was found in the input.")
+        print("⚠️ No authorization code was found in the input.")
         return None
 
     def _callback_capture_script(self):
@@ -228,19 +198,13 @@ class PixivTokenFetcher:
 })();
 '''
 
-    def _slow_type(self, page, selector: str, text: str, delay: Optional[float] = None):
-        if delay is None:
-            delay = self.typing_delay
-
+    def _slow_type(self, page, selector, text, delay=0.08):
         page.focus(selector)
         for char in text:
             page.keyboard.insert_text(char)
             time.sleep(delay)
 
-    def _find_input(self, page, selectors: list, timeout: Optional[int] = None):
-        if timeout is None:
-            timeout = self.input_timeout
-
+    def _find_input(self, page, selectors, timeout=3000):
         for selector in selectors:
             try:
                 el = page.wait_for_selector(selector, timeout=timeout)
@@ -253,11 +217,11 @@ class PixivTokenFetcher:
     def _perform_login(self, page):
         email_selector = self._find_input(page, EMAIL_SELECTORS)
         if not email_selector:
-            logger.warning("Warning: username input not found")
+            print("⚠️ Username input not found")
             return
 
         self._slow_type(page, email_selector, self.username)
-        logger.info("Username input completed")
+        print("📧 Username input completed")
 
         pwd_selector = self._find_input(page, PASSWORD_SELECTORS)
         if not pwd_selector:
@@ -266,37 +230,24 @@ class PixivTokenFetcher:
             pwd_selector = self._find_input(page, PASSWORD_SELECTORS)
 
         if not pwd_selector:
-            logger.warning("Warning: password input not found")
+            print("⚠️ Password input not found")
             return
 
         self._slow_type(page, pwd_selector, self.password)
-        logger.info("Password input completed")
+        print("🔒 Password input completed")
 
         login_btn = page.locator("button:has-text('ログイン')")
         if login_btn.count() > 0:
             login_btn.first.click()
         else:
             page.keyboard.press("Enter")
-        logger.info("Login submitted")
-
-    def _goto_login_page(self, page, login_url: str) -> None:
-        try:
-            page.goto(
-                login_url,
-                wait_until="domcontentloaded",
-                timeout=self.navigation_timeout,
-            )
-        except TimeoutError:
-            logger.warning(
-                "Login page navigation timed out after %sms; continuing with the current page state.",
-                self.navigation_timeout,
-            )
+        print("🔑 Login submitted")
 
     def _skip_security_prompts(self, page):
         for btn_text in SKIP_BUTTON_TEXTS:
             btn = page.locator(f"button:has-text('{btn_text}')")
             if btn.count() > 0 and btn.first.is_visible():
-                logger.info("  Clicking '%s' to skip security prompt", btn_text)
+                print(f"  Clicking '{btn_text}' to skip security prompt")
                 btn.first.click()
                 time.sleep(1)
                 return True
@@ -308,109 +259,97 @@ class PixivTokenFetcher:
                 "headless": self.headless,
                 "args": self._launch_args(),
             }
-            browser_path = self._browser_executable_path()
+            browser_path = self._browser_executable_path(p)
             if browser_path:
                 launch_options["executable_path"] = browser_path
 
-            browser = None
-            context = None
+            browser = p.chromium.launch(**launch_options)
+            context = browser.new_context(
+                user_agent=BROWSER_UA,
+                viewport={"width": 1280, "height": 720},
+                locale="ja-JP",
+            )
+            context.add_init_script(self._callback_capture_script())
+            page = context.new_page()
+            cdp_session = context.new_cdp_session(page)
+            cdp_session.send("Network.enable")
+            cdp_session.send("Page.enable")
+
+            captured_code = {"value": None}
+
+            def try_capture(value, source):
+                if captured_code["value"]:
+                    return
+
+                code = self._extract_code(value)
+                if not code:
+                    return
+
+                captured_code["value"] = code
+                print("✅ Code captured:", code, flush=True)
+                try:
+                    page.close()
+                except Exception:
+                    pass
+
+            def on_request_will_be_sent(event):
+                if not isinstance(event, dict):
+                    return
+
+                request = event.get("request")
+                if isinstance(request, dict):
+                    try_capture(request.get("url", ""), "cdp request")
+                try_capture(event.get("documentURL", ""), "cdp document")
+
+            def on_console(message):
+                text = message.text or ""
+                if text.startswith(CONSOLE_CODE_PREFIX):
+                    try_capture("code=" + text[len(CONSOLE_CODE_PREFIX):], "console script")
+                elif text.startswith(CONSOLE_CALLBACK_PREFIX):
+                    try_capture(text[len(CONSOLE_CALLBACK_PREFIX):], "console script")
+
+            def on_page_navigation(event):
+                if isinstance(event, dict):
+                    try_capture(event.get("url", ""), "cdp navigation")
+
+            cdp_session.on("Network.requestWillBeSent", on_request_will_be_sent)
+            cdp_session.on("Page.frameScheduledNavigation", on_page_navigation)
+            cdp_session.on("Page.frameRequestedNavigation", on_page_navigation)
+            page.on("request", lambda request: try_capture(request.url, "request"))
+            page.on("response", lambda response: try_capture(response.url, "response"))
+            page.on("framenavigated", lambda frame: try_capture(frame.url, "frame navigation"))
+            page.on("console", on_console)
+
+            print("🚀 Opening Pixiv login page...")
             try:
-                browser = p.chromium.launch(**launch_options)
-                context = browser.new_context(
-                    user_agent=BROWSER_UA,
-                    viewport={"width": 1280, "height": 720},
-                    locale="ja-JP",
-                )
-                context.add_init_script(self._callback_capture_script())
-                page = context.new_page()
-                cdp_session = context.new_cdp_session(page)
-                cdp_session.send("Network.enable")
-                cdp_session.send("Page.enable")
+                page.goto(self._get_login_url(), wait_until="domcontentloaded", timeout=60000)
+            except TimeoutError:
+                print("⚠️ Login page navigation timed out; continuing.")
+            self._perform_login(page)
 
-                captured_code = {"value": None}
+            for _ in range(60):
+                if captured_code["value"] or page.is_closed():
+                    break
+                try:
+                    self._skip_security_prompts(page)
+                except Exception:
+                    pass
+                time.sleep(1)
 
-                def try_capture(value, source):
-                    if captured_code["value"]:
-                        return
+            if not captured_code["value"]:
+                print("⌛ Timeout: Code not captured.")
+                captured_code["value"] = self._read_manual_code()
 
-                    code = self._extract_code(value)
-                    if not code:
-                        return
+            browser.close()
+            return captured_code["value"]
 
-                    captured_code["value"] = code
-                    logger.info("Code captured from %s: %s", source, code)
-                    try:
-                        page.close()
-                    except Exception:
-                        logger.debug("Failed to close page after code capture.", exc_info=True)
-
-                def on_request_will_be_sent(event):
-                    if not isinstance(event, dict):
-                        return
-
-                    request = event.get("request")
-                    if isinstance(request, dict):
-                        try_capture(request.get("url", ""), "cdp request")
-                    try_capture(event.get("documentURL", ""), "cdp document")
-
-                def on_console(message):
-                    text = message.text or ""
-                    if text.startswith(CONSOLE_CODE_PREFIX):
-                        try_capture("code=" + text[len(CONSOLE_CODE_PREFIX):], "console script")
-                    elif text.startswith(CONSOLE_CALLBACK_PREFIX):
-                        try_capture(text[len(CONSOLE_CALLBACK_PREFIX):], "console script")
-
-                def on_page_navigation(event):
-                    if isinstance(event, dict):
-                        try_capture(event.get("url", ""), "cdp navigation")
-
-                cdp_session.on("Network.requestWillBeSent", on_request_will_be_sent)
-                cdp_session.on("Page.frameScheduledNavigation", on_page_navigation)
-                cdp_session.on("Page.frameRequestedNavigation", on_page_navigation)
-                page.on("request", lambda request: try_capture(request.url, "request"))
-                page.on("response", lambda response: try_capture(response.url, "response"))
-                page.on("framenavigated", lambda frame: try_capture(frame.url, "frame navigation"))
-                page.on("console", on_console)
-
-                logger.info("Opening Pixiv login page...")
-                login_url = self._get_login_url()
-                logger.info("Login URL: %s", login_url)
-                self._goto_login_page(page, login_url)
-                self._perform_login(page)
-
-                for _ in range(self.capture_timeout):
-                    if captured_code["value"] or page.is_closed():
-                        break
-                    try:
-                        self._skip_security_prompts(page)
-                    except Exception:
-                        logger.debug("Failed to handle security prompt.", exc_info=True)
-                    time.sleep(1)
-
-                if not captured_code["value"]:
-                    logger.warning("Timeout: code was not captured.")
-                    captured_code["value"] = self._read_manual_code()
-
-                return captured_code["value"]
-            finally:
-                if context is not None:
-                    try:
-                        context.close()
-                    except Exception:
-                        logger.debug("Failed to close browser context.", exc_info=True)
-                if browser is not None:
-                    try:
-                        browser.close()
-                    except Exception:
-                        logger.debug("Failed to close browser.", exc_info=True)
-
-    def _post_token(self, data: Dict[str, str]) -> Dict[str, Any]:
+    def _post_token(self, data):
         try:
             resp = requests.post(
                 PIXIV_TOKEN_URL,
                 data=data,
                 headers={"User-Agent": API_UA},
-                timeout=self.request_timeout,
+                timeout=30,
             )
         except requests.RequestException as exc:
             raise PixivTokenError(f"Token request failed: {exc}") from exc
@@ -431,10 +370,7 @@ class PixivTokenFetcher:
         except ValueError as exc:
             raise PixivTokenError("Token response was not valid JSON") from exc
 
-    def exchange_token(self, code: str) -> Dict[str, Any]:
-        if not code:
-            raise ValueError("code must not be empty")
-
+    def exchange_token(self, code):
         return self._post_token({
             "client_id": PIXIV_CLIENT_ID,
             "client_secret": PIXIV_CLIENT_SECRET,
@@ -445,10 +381,7 @@ class PixivTokenFetcher:
             "include_policy": "true",
         })
 
-    def refresh_token(self, refresh_token: str) -> Dict[str, Any]:
-        if not refresh_token:
-            raise ValueError("refresh_token must not be empty")
-
+    def refresh_token(self, refresh_token):
         return self._post_token({
             "client_id": PIXIV_CLIENT_ID,
             "client_secret": PIXIV_CLIENT_SECRET,
@@ -461,51 +394,12 @@ class PixivTokenFetcher:
 if __name__ == "__main__":
     import argparse
     import getpass
-    logging.basicConfig(level=logging.INFO, format="%(message)s")
 
     parser = argparse.ArgumentParser(description="Fetch Pixiv OAuth refresh token")
     parser.add_argument("--username", "-u", help="Pixiv account email or username")
     parser.add_argument("--password", "-p", help="Pixiv account password")
-    parser.add_argument(
-        "--headless",
-        action="store_true",
-        help="Run without showing the browser window",
-    )
-    parser.add_argument(
-        "--no-headless",
-        action="store_true",
-        help=argparse.SUPPRESS,
-    )
-    parser.add_argument(
-        "--capture-timeout",
-        type=int,
-        default=DEFAULT_CAPTURE_TIMEOUT,
-        help="Seconds to wait for the OAuth callback before manual fallback",
-    )
-    parser.add_argument(
-        "--input-timeout",
-        type=int,
-        default=DEFAULT_INPUT_TIMEOUT,
-        help="Milliseconds to wait for each login input selector",
-    )
-    parser.add_argument(
-        "--navigation-timeout",
-        type=int,
-        default=DEFAULT_NAVIGATION_TIMEOUT,
-        help="Milliseconds to wait for Pixiv login page navigation",
-    )
-    parser.add_argument(
-        "--request-timeout",
-        type=float,
-        default=DEFAULT_REQUEST_TIMEOUT,
-        help="Seconds to wait for the Pixiv token HTTP request",
-    )
-    parser.add_argument(
-        "--typing-delay",
-        type=float,
-        default=DEFAULT_TYPING_DELAY,
-        help="Seconds to wait between typed characters",
-    )
+    parser.add_argument("--headless", action="store_true", help="Run without showing the browser window")
+    parser.add_argument("--no-headless", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
 
     username = args.username
@@ -513,42 +407,40 @@ if __name__ == "__main__":
     if not username:
         if not sys.stdin.isatty():
             parser.error("--username is required when stdin is not interactive")
-        try:
-            username = input("Pixiv username/email: ").strip()
-        except EOFError:
-            parser.error("--username is required when stdin cannot be read")
+        username = input("Pixiv username/email: ").strip()
     if not password:
         if not sys.stdin.isatty():
             parser.error("--password is required when stdin is not interactive")
-        try:
-            password = getpass.getpass("Pixiv password: ")
-        except EOFError:
-            parser.error("--password is required when stdin cannot be read")
+        password = getpass.getpass("Pixiv password: ")
 
-    if not username:
-        parser.error("username must not be empty")
-    if not password:
-        parser.error("password must not be empty")
+    if args.headless and not args.no_headless:
+        headless = True
+    elif args.no_headless:
+        headless = False
+    elif sys.stdin.isatty():
+        choice = input("Open browser window? (Y/n): ").strip().lower()
+        headless = (choice == "n")
+    else:
+        headless = False
 
-    fetcher = PixivTokenFetcher(
-        username,
-        password,
-        headless=args.headless and not args.no_headless,
-        capture_timeout=args.capture_timeout,
-        input_timeout=args.input_timeout,
-        navigation_timeout=args.navigation_timeout,
-        request_timeout=args.request_timeout,
-        typing_delay=args.typing_delay,
-    )
+    fetcher = PixivTokenFetcher(username, password, headless=headless)
     code = fetcher.fetch_code()
-    if code:
+    if not code:
+        print("❌ Failed to retrieve authorization code.")
+        sys.exit(1)
+
+    while True:
         try:
             token_info = fetcher.exchange_token(code)
+            break
         except PixivTokenError as exc:
-            logger.error("Failed to exchange token: %s", exc)
-            sys.exit(1)
-        print(f"Access Token: {token_info.get('access_token')}")
-        print(f"Refresh Token: {token_info.get('refresh_token')}")
-    else:
-        logger.error("Failed to retrieve authorization code.")
-        sys.exit(1)
+            print(f"❌ Failed to exchange token: {exc}")
+            if not sys.stdin.isatty():
+                sys.exit(1)
+            choice = input("Retry token exchange? (Y/n): ").strip().lower()
+            if choice == "n":
+                sys.exit(1)
+            print("🔁 Retrying...")
+
+    print(f"🎟️ Access Token: {token_info.get('access_token')}")
+    print(f"🔁 Refresh Token: {token_info.get('refresh_token')}")

--- a/pixiv_token_fetcher.py
+++ b/pixiv_token_fetcher.py
@@ -1,9 +1,12 @@
 import base64
 import hashlib
+import os
 import secrets
+import sys
 import requests
 import time
 import re
+from urllib.parse import unquote
 from playwright.sync_api import sync_playwright, TimeoutError
 
 PIXIV_CLIENT_ID = "MOBrBDS8blbauoSck0ZfDbtuzpyT"
@@ -15,6 +18,9 @@ BROWSER_UA = (
     "(KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
 )
 API_UA = "PixivAndroidApp/5.0.234 (Android 11; Pixel 5)"
+CALLBACK_URL_PREFIX = "pixiv://account/login"
+CONSOLE_CODE_PREFIX = "[PIXIV-CODE]"
+CONSOLE_CALLBACK_PREFIX = "[PIXIV-CALLBACK]"
 
 EMAIL_SELECTORS = [
     "input[autocomplete^='username']",
@@ -27,6 +33,12 @@ PASSWORD_SELECTORS = [
     "input[type='password']",
 ]
 SKIP_BUTTON_TEXTS = ["Remind me later", "Skip", "あとで", "スキップ"]
+DEFAULT_BROWSER_PATHS = [
+    r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+    r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
+    r"C:\Program Files\Microsoft\Edge\Application\msedge.exe",
+    r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe",
+]
 
 
 class PixivTokenFetcher:
@@ -40,10 +52,18 @@ class PixivTokenFetcher:
         ).rstrip(b'=').decode('ascii')
 
     def _launch_args(self):
-        base_args = ["--disable-blink-features=AutomationControlled"]
-        if self.headless:
-            base_args.append("--headless=new")
-        return base_args
+        return ["--disable-blink-features=AutomationControlled"]
+
+    def _browser_executable_path(self):
+        configured_path = os.getenv("PIXIV_BROWSER_PATH")
+        if configured_path and os.path.exists(configured_path):
+            return configured_path
+
+        for browser_path in DEFAULT_BROWSER_PATHS:
+            if os.path.exists(browser_path):
+                return browser_path
+
+        return None
 
     def _get_login_url(self):
         return (
@@ -51,6 +71,122 @@ class PixivTokenFetcher:
             f"code_challenge={self.code_challenge}&"
             "code_challenge_method=S256&client=pixiv-android"
         )
+
+    def _extract_code(self, value: str):
+        if not value:
+            return None
+
+        candidates = [value]
+        try:
+            candidates.append(unquote(value))
+        except Exception:
+            pass
+
+        for candidate in candidates:
+            if CALLBACK_URL_PREFIX in candidate:
+                candidate = candidate[candidate.find(CALLBACK_URL_PREFIX):]
+
+            match = re.search(r"(?:^|[?&])code=([^&#\s\"'<>)]*)", candidate)
+            if match:
+                return unquote(match.group(1))
+
+        return None
+
+    def _read_manual_code(self):
+        if not sys.stdin.isatty():
+            return None
+
+        print("\nCode was not captured automatically.")
+        print("Paste the full pixiv://account/login?code=... callback URL if you can find it.")
+        print("You can also paste only the code value. Press Enter to skip.")
+
+        manual_value = input("Paste callback URL or code: ").strip()
+        if not manual_value:
+            return None
+
+        extracted_code = self._extract_code(manual_value)
+        if extracted_code:
+            return extracted_code
+
+        if re.fullmatch(r"[A-Za-z0-9_-]+", manual_value):
+            return manual_value
+
+        print("No authorization code was found in the input.")
+        return None
+
+    def _callback_capture_script(self):
+        return r'''
+(() => {
+    const CODE_PREFIX = "[PIXIV-CODE]";
+    const CALLBACK_PREFIX = "[PIXIV-CALLBACK]";
+    const seen = new Set();
+
+    function capture(value, source) {
+        if (!value || typeof value !== "string") return;
+        if (seen.has(source + value)) return;
+        seen.add(source + value);
+
+        const candidates = [value];
+        try { candidates.push(decodeURIComponent(value)); } catch (_) {}
+
+        for (const candidate of candidates) {
+            const callbackMatch = candidate.match(/pixiv:\/\/account\/login[^\s"'<>)]*/i);
+            const target = callbackMatch ? callbackMatch[0] : candidate;
+            const codeMatch = target.match(/[?&]code=([^&#\s"'<>)]*)/);
+            if (!codeMatch) continue;
+
+            const code = decodeURIComponent(codeMatch[1]);
+            console.log(CODE_PREFIX + code);
+            console.log(CALLBACK_PREFIX + target);
+            window.__PIXIV_OAUTH_CODE__ = code;
+            window.__PIXIV_OAUTH_CALLBACK__ = target;
+            break;
+        }
+    }
+
+    function scan() {
+        capture(location.href, "location.href");
+        for (const entry of performance.getEntries()) {
+            capture(entry.name, "performance");
+        }
+        for (const element of document.querySelectorAll("a[href], form[action]")) {
+            capture(element.href || element.action, "dom");
+        }
+    }
+
+    function patch(object, name, getValue) {
+        try {
+            const original = object[name];
+            if (typeof original !== "function") return;
+            object[name] = function (...args) {
+                capture(String(getValue(args) || ""), name);
+                return original.apply(this, args);
+            };
+        } catch (_) {}
+    }
+
+    patch(window, "open", args => args[0]);
+    patch(Location.prototype, "assign", args => args[0]);
+    patch(Location.prototype, "replace", args => args[0]);
+    patch(history, "pushState", args => args[2]);
+    patch(history, "replaceState", args => args[2]);
+
+    document.addEventListener("click", event => {
+        const link = event.target && event.target.closest ? event.target.closest("a[href]") : null;
+        if (link) capture(link.href, "click");
+    }, true);
+
+    new MutationObserver(scan).observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ["href", "action"],
+    });
+
+    setInterval(scan, 250);
+    scan();
+})();
+'''
 
     def _slow_type(self, page, selector: str, text: str, delay: float = 0.08):
         page.focus(selector)
@@ -71,11 +207,11 @@ class PixivTokenFetcher:
     def _perform_login(self, page):
         email_selector = self._find_input(page, EMAIL_SELECTORS)
         if not email_selector:
-            print("⚠️ Username input not found")
+            print("Warning: username input not found")
             return
 
         self._slow_type(page, email_selector, self.username)
-        print("📧 Username input completed")
+        print("Username input completed")
 
         pwd_selector = self._find_input(page, PASSWORD_SELECTORS)
         if not pwd_selector:
@@ -84,18 +220,18 @@ class PixivTokenFetcher:
             pwd_selector = self._find_input(page, PASSWORD_SELECTORS)
 
         if not pwd_selector:
-            print("⚠️ Password input not found")
+            print("Warning: password input not found")
             return
 
         self._slow_type(page, pwd_selector, self.password)
-        print("🔒 Password input completed")
+        print("Password input completed")
 
         login_btn = page.locator("button:has-text('ログイン')")
         if login_btn.count() > 0:
             login_btn.first.click()
         else:
             page.keyboard.press("Enter")
-        print("🔑 Login submitted")
+        print("Login submitted")
 
     def _skip_security_prompts(self, page):
         for btn_text in SKIP_BUTTON_TEXTS:
@@ -109,35 +245,72 @@ class PixivTokenFetcher:
 
     def fetch_code(self):
         with sync_playwright() as p:
-            browser = p.chromium.launch(headless=False, args=self._launch_args())
+            launch_options = {
+                "headless": self.headless,
+                "args": self._launch_args(),
+            }
+            browser_path = self._browser_executable_path()
+            if browser_path:
+                launch_options["executable_path"] = browser_path
+
+            browser = p.chromium.launch(**launch_options)
             context = browser.new_context(
                 user_agent=BROWSER_UA,
                 viewport={"width": 1280, "height": 720},
                 locale="ja-JP",
             )
+            context.add_init_script(self._callback_capture_script())
             page = context.new_page()
             cdp_session = context.new_cdp_session(page)
             cdp_session.send("Network.enable")
+            cdp_session.send("Page.enable")
 
             captured_code = {"value": None}
 
+            def try_capture(value, source):
+                if captured_code["value"]:
+                    return
+
+                code = self._extract_code(value)
+                if not code:
+                    return
+
+                captured_code["value"] = code
+                print(f"Code captured from {source}: {code}", flush=True)
+                try:
+                    page.close()
+                except Exception:
+                    pass
+
             def on_request_will_be_sent(event):
-                url = event.get("request", {}).get("url", "")
-                check_url = url or event.get("documentURL", "")
-                if check_url.startswith("pixiv://account/login"):
-                    match = re.search(r"code=([\w-]+)", check_url)
-                    if match:
-                        captured_code["value"] = match.group(1)
-                        print("✅ Code captured:", captured_code["value"], flush=True)
-                        page.close()
+                try_capture(event.get("request", {}).get("url", ""), "cdp request")
+                try_capture(event.get("documentURL", ""), "cdp document")
+
+            def on_console(message):
+                text = message.text
+                if text.startswith(CONSOLE_CODE_PREFIX):
+                    try_capture("code=" + text[len(CONSOLE_CODE_PREFIX):], "console script")
+                elif text.startswith(CONSOLE_CALLBACK_PREFIX):
+                    try_capture(text[len(CONSOLE_CALLBACK_PREFIX):], "console script")
+
+            def on_page_navigation(event):
+                try_capture(event.get("url", ""), "cdp navigation")
 
             cdp_session.on("Network.requestWillBeSent", on_request_will_be_sent)
+            cdp_session.on("Page.frameScheduledNavigation", on_page_navigation)
+            cdp_session.on("Page.frameRequestedNavigation", on_page_navigation)
+            page.on("request", lambda request: try_capture(request.url, "request"))
+            page.on("response", lambda response: try_capture(response.url, "response"))
+            page.on("framenavigated", lambda frame: try_capture(frame.url, "frame navigation"))
+            page.on("console", on_console)
 
-            print("🚀 Opening Pixiv login page...")
-            page.goto(self._get_login_url())
+            print("Opening Pixiv login page...")
+            login_url = self._get_login_url()
+            print("Login URL:", login_url)
+            page.goto(login_url)
             self._perform_login(page)
 
-            for _ in range(30):
+            for _ in range(60):
                 if captured_code["value"] or page.is_closed():
                     break
                 try:
@@ -147,7 +320,8 @@ class PixivTokenFetcher:
                 time.sleep(1)
 
             if not captured_code["value"]:
-                print("⌛ Timeout: Code not captured.")
+                print("Timeout: code was not captured.")
+                captured_code["value"] = self._read_manual_code()
 
             browser.close()
             return captured_code["value"]
@@ -177,7 +351,7 @@ if __name__ == "__main__":
     code = fetcher.fetch_code()
     if code:
         token_info = fetcher.exchange_token(code)
-        print(f"🎟️ Access Token: {token_info.get('access_token')}")
-        print(f"🔁 Refresh Token: {token_info.get('refresh_token')}")
+        print(f"Access Token: {token_info.get('access_token')}")
+        print(f"Refresh Token: {token_info.get('refresh_token')}")
     else:
-        print("❌ Failed to retrieve authorization code.")
+        print("Failed to retrieve authorization code.")

--- a/pixiv_token_fetcher.py
+++ b/pixiv_token_fetcher.py
@@ -1,11 +1,13 @@
 import base64
 import hashlib
+import logging
 import os
 import secrets
 import sys
 import requests
 import time
 import re
+from typing import Any, Dict, Optional
 from urllib.parse import unquote
 from playwright.sync_api import sync_playwright, TimeoutError
 
@@ -21,6 +23,14 @@ API_UA = "PixivAndroidApp/5.0.234 (Android 11; Pixel 5)"
 CALLBACK_URL_PREFIX = "pixiv://account/login"
 CONSOLE_CODE_PREFIX = "[PIXIV-CODE]"
 CONSOLE_CALLBACK_PREFIX = "[PIXIV-CALLBACK]"
+AUTH_CODE_PATTERN = re.compile(r"(?:^|[?&])code=([^&#\s\"'<>)]*)")
+DEFAULT_CAPTURE_TIMEOUT = 60
+DEFAULT_INPUT_TIMEOUT = 3000
+DEFAULT_NAVIGATION_TIMEOUT = 60000
+DEFAULT_REQUEST_TIMEOUT = 30
+DEFAULT_TYPING_DELAY = 0.08
+
+logger = logging.getLogger(__name__)
 
 EMAIL_SELECTORS = [
     "input[autocomplete^='username']",
@@ -41,11 +51,41 @@ DEFAULT_BROWSER_PATHS = [
 ]
 
 
+class PixivTokenError(RuntimeError):
+    """Raised when token exchange fails."""
+
+
 class PixivTokenFetcher:
-    def __init__(self, username: str, password: str, headless=True):
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        headless: bool = False,
+        capture_timeout: int = DEFAULT_CAPTURE_TIMEOUT,
+        input_timeout: int = DEFAULT_INPUT_TIMEOUT,
+        navigation_timeout: int = DEFAULT_NAVIGATION_TIMEOUT,
+        request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
+        typing_delay: float = DEFAULT_TYPING_DELAY,
+    ):
+        if capture_timeout <= 0:
+            raise ValueError("capture_timeout must be greater than 0")
+        if input_timeout <= 0:
+            raise ValueError("input_timeout must be greater than 0")
+        if navigation_timeout <= 0:
+            raise ValueError("navigation_timeout must be greater than 0")
+        if request_timeout <= 0:
+            raise ValueError("request_timeout must be greater than 0")
+        if typing_delay < 0:
+            raise ValueError("typing_delay must be greater than or equal to 0")
+
         self.headless = headless
         self.username = username
         self.password = password
+        self.capture_timeout = capture_timeout
+        self.input_timeout = input_timeout
+        self.navigation_timeout = navigation_timeout
+        self.request_timeout = request_timeout
+        self.typing_delay = typing_delay
         self.code_verifier = secrets.token_urlsafe(64)
         self.code_challenge = base64.urlsafe_b64encode(
             hashlib.sha256(self.code_verifier.encode()).digest()
@@ -72,7 +112,7 @@ class PixivTokenFetcher:
             "code_challenge_method=S256&client=pixiv-android"
         )
 
-    def _extract_code(self, value: str):
+    def _extract_code(self, value: str) -> Optional[str]:
         if not value:
             return None
 
@@ -86,13 +126,13 @@ class PixivTokenFetcher:
             if CALLBACK_URL_PREFIX in candidate:
                 candidate = candidate[candidate.find(CALLBACK_URL_PREFIX):]
 
-            match = re.search(r"(?:^|[?&])code=([^&#\s\"'<>)]*)", candidate)
+            match = AUTH_CODE_PATTERN.search(candidate)
             if match:
                 return unquote(match.group(1))
 
         return None
 
-    def _read_manual_code(self):
+    def _read_manual_code(self) -> Optional[str]:
         if not sys.stdin.isatty():
             return None
 
@@ -188,13 +228,19 @@ class PixivTokenFetcher:
 })();
 '''
 
-    def _slow_type(self, page, selector: str, text: str, delay: float = 0.08):
+    def _slow_type(self, page, selector: str, text: str, delay: Optional[float] = None):
+        if delay is None:
+            delay = self.typing_delay
+
         page.focus(selector)
         for char in text:
             page.keyboard.insert_text(char)
             time.sleep(delay)
 
-    def _find_input(self, page, selectors: list, timeout=3000):
+    def _find_input(self, page, selectors: list, timeout: Optional[int] = None):
+        if timeout is None:
+            timeout = self.input_timeout
+
         for selector in selectors:
             try:
                 el = page.wait_for_selector(selector, timeout=timeout)
@@ -207,11 +253,11 @@ class PixivTokenFetcher:
     def _perform_login(self, page):
         email_selector = self._find_input(page, EMAIL_SELECTORS)
         if not email_selector:
-            print("Warning: username input not found")
+            logger.warning("Warning: username input not found")
             return
 
         self._slow_type(page, email_selector, self.username)
-        print("Username input completed")
+        logger.info("Username input completed")
 
         pwd_selector = self._find_input(page, PASSWORD_SELECTORS)
         if not pwd_selector:
@@ -220,24 +266,37 @@ class PixivTokenFetcher:
             pwd_selector = self._find_input(page, PASSWORD_SELECTORS)
 
         if not pwd_selector:
-            print("Warning: password input not found")
+            logger.warning("Warning: password input not found")
             return
 
         self._slow_type(page, pwd_selector, self.password)
-        print("Password input completed")
+        logger.info("Password input completed")
 
         login_btn = page.locator("button:has-text('ログイン')")
         if login_btn.count() > 0:
             login_btn.first.click()
         else:
             page.keyboard.press("Enter")
-        print("Login submitted")
+        logger.info("Login submitted")
+
+    def _goto_login_page(self, page, login_url: str) -> None:
+        try:
+            page.goto(
+                login_url,
+                wait_until="domcontentloaded",
+                timeout=self.navigation_timeout,
+            )
+        except TimeoutError:
+            logger.warning(
+                "Login page navigation timed out after %sms; continuing with the current page state.",
+                self.navigation_timeout,
+            )
 
     def _skip_security_prompts(self, page):
         for btn_text in SKIP_BUTTON_TEXTS:
             btn = page.locator(f"button:has-text('{btn_text}')")
             if btn.count() > 0 and btn.first.is_visible():
-                print(f"  Clicking '{btn_text}' to skip security prompt")
+                logger.info("  Clicking '%s' to skip security prompt", btn_text)
                 btn.first.click()
                 time.sleep(1)
                 return True
@@ -253,81 +312,130 @@ class PixivTokenFetcher:
             if browser_path:
                 launch_options["executable_path"] = browser_path
 
-            browser = p.chromium.launch(**launch_options)
-            context = browser.new_context(
-                user_agent=BROWSER_UA,
-                viewport={"width": 1280, "height": 720},
-                locale="ja-JP",
+            browser = None
+            context = None
+            try:
+                browser = p.chromium.launch(**launch_options)
+                context = browser.new_context(
+                    user_agent=BROWSER_UA,
+                    viewport={"width": 1280, "height": 720},
+                    locale="ja-JP",
+                )
+                context.add_init_script(self._callback_capture_script())
+                page = context.new_page()
+                cdp_session = context.new_cdp_session(page)
+                cdp_session.send("Network.enable")
+                cdp_session.send("Page.enable")
+
+                captured_code = {"value": None}
+
+                def try_capture(value, source):
+                    if captured_code["value"]:
+                        return
+
+                    code = self._extract_code(value)
+                    if not code:
+                        return
+
+                    captured_code["value"] = code
+                    logger.info("Code captured from %s: %s", source, code)
+                    try:
+                        page.close()
+                    except Exception:
+                        logger.debug("Failed to close page after code capture.", exc_info=True)
+
+                def on_request_will_be_sent(event):
+                    if not isinstance(event, dict):
+                        return
+
+                    request = event.get("request")
+                    if isinstance(request, dict):
+                        try_capture(request.get("url", ""), "cdp request")
+                    try_capture(event.get("documentURL", ""), "cdp document")
+
+                def on_console(message):
+                    text = message.text or ""
+                    if text.startswith(CONSOLE_CODE_PREFIX):
+                        try_capture("code=" + text[len(CONSOLE_CODE_PREFIX):], "console script")
+                    elif text.startswith(CONSOLE_CALLBACK_PREFIX):
+                        try_capture(text[len(CONSOLE_CALLBACK_PREFIX):], "console script")
+
+                def on_page_navigation(event):
+                    if isinstance(event, dict):
+                        try_capture(event.get("url", ""), "cdp navigation")
+
+                cdp_session.on("Network.requestWillBeSent", on_request_will_be_sent)
+                cdp_session.on("Page.frameScheduledNavigation", on_page_navigation)
+                cdp_session.on("Page.frameRequestedNavigation", on_page_navigation)
+                page.on("request", lambda request: try_capture(request.url, "request"))
+                page.on("response", lambda response: try_capture(response.url, "response"))
+                page.on("framenavigated", lambda frame: try_capture(frame.url, "frame navigation"))
+                page.on("console", on_console)
+
+                logger.info("Opening Pixiv login page...")
+                login_url = self._get_login_url()
+                logger.info("Login URL: %s", login_url)
+                self._goto_login_page(page, login_url)
+                self._perform_login(page)
+
+                for _ in range(self.capture_timeout):
+                    if captured_code["value"] or page.is_closed():
+                        break
+                    try:
+                        self._skip_security_prompts(page)
+                    except Exception:
+                        logger.debug("Failed to handle security prompt.", exc_info=True)
+                    time.sleep(1)
+
+                if not captured_code["value"]:
+                    logger.warning("Timeout: code was not captured.")
+                    captured_code["value"] = self._read_manual_code()
+
+                return captured_code["value"]
+            finally:
+                if context is not None:
+                    try:
+                        context.close()
+                    except Exception:
+                        logger.debug("Failed to close browser context.", exc_info=True)
+                if browser is not None:
+                    try:
+                        browser.close()
+                    except Exception:
+                        logger.debug("Failed to close browser.", exc_info=True)
+
+    def _post_token(self, data: Dict[str, str]) -> Dict[str, Any]:
+        try:
+            resp = requests.post(
+                PIXIV_TOKEN_URL,
+                data=data,
+                headers={"User-Agent": API_UA},
+                timeout=self.request_timeout,
             )
-            context.add_init_script(self._callback_capture_script())
-            page = context.new_page()
-            cdp_session = context.new_cdp_session(page)
-            cdp_session.send("Network.enable")
-            cdp_session.send("Page.enable")
+        except requests.RequestException as exc:
+            raise PixivTokenError(f"Token request failed: {exc}") from exc
 
-            captured_code = {"value": None}
+        try:
+            resp.raise_for_status()
+        except requests.HTTPError as exc:
+            response_text = resp.text.strip()
+            if len(response_text) > 500:
+                response_text = response_text[:497] + "..."
+            detail = f": {response_text}" if response_text else ""
+            raise PixivTokenError(
+                f"Token request failed with HTTP {resp.status_code}{detail}"
+            ) from exc
 
-            def try_capture(value, source):
-                if captured_code["value"]:
-                    return
+        try:
+            return resp.json()
+        except ValueError as exc:
+            raise PixivTokenError("Token response was not valid JSON") from exc
 
-                code = self._extract_code(value)
-                if not code:
-                    return
+    def exchange_token(self, code: str) -> Dict[str, Any]:
+        if not code:
+            raise ValueError("code must not be empty")
 
-                captured_code["value"] = code
-                print(f"Code captured from {source}: {code}", flush=True)
-                try:
-                    page.close()
-                except Exception:
-                    pass
-
-            def on_request_will_be_sent(event):
-                try_capture(event.get("request", {}).get("url", ""), "cdp request")
-                try_capture(event.get("documentURL", ""), "cdp document")
-
-            def on_console(message):
-                text = message.text
-                if text.startswith(CONSOLE_CODE_PREFIX):
-                    try_capture("code=" + text[len(CONSOLE_CODE_PREFIX):], "console script")
-                elif text.startswith(CONSOLE_CALLBACK_PREFIX):
-                    try_capture(text[len(CONSOLE_CALLBACK_PREFIX):], "console script")
-
-            def on_page_navigation(event):
-                try_capture(event.get("url", ""), "cdp navigation")
-
-            cdp_session.on("Network.requestWillBeSent", on_request_will_be_sent)
-            cdp_session.on("Page.frameScheduledNavigation", on_page_navigation)
-            cdp_session.on("Page.frameRequestedNavigation", on_page_navigation)
-            page.on("request", lambda request: try_capture(request.url, "request"))
-            page.on("response", lambda response: try_capture(response.url, "response"))
-            page.on("framenavigated", lambda frame: try_capture(frame.url, "frame navigation"))
-            page.on("console", on_console)
-
-            print("Opening Pixiv login page...")
-            login_url = self._get_login_url()
-            print("Login URL:", login_url)
-            page.goto(login_url)
-            self._perform_login(page)
-
-            for _ in range(60):
-                if captured_code["value"] or page.is_closed():
-                    break
-                try:
-                    self._skip_security_prompts(page)
-                except Exception:
-                    pass
-                time.sleep(1)
-
-            if not captured_code["value"]:
-                print("Timeout: code was not captured.")
-                captured_code["value"] = self._read_manual_code()
-
-            browser.close()
-            return captured_code["value"]
-
-    def exchange_token(self, code):
-        resp = requests.post(PIXIV_TOKEN_URL, data={
+        return self._post_token({
             "client_id": PIXIV_CLIENT_ID,
             "client_secret": PIXIV_CLIENT_SECRET,
             "grant_type": "authorization_code",
@@ -335,23 +443,112 @@ class PixivTokenFetcher:
             "code_verifier": self.code_verifier,
             "redirect_uri": REDIRECT_URI,
             "include_policy": "true",
-        }, headers={"User-Agent": API_UA})
-        return resp.json()
+        })
+
+    def refresh_token(self, refresh_token: str) -> Dict[str, Any]:
+        if not refresh_token:
+            raise ValueError("refresh_token must not be empty")
+
+        return self._post_token({
+            "client_id": PIXIV_CLIENT_ID,
+            "client_secret": PIXIV_CLIENT_SECRET,
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "include_policy": "true",
+        })
 
 
 if __name__ == "__main__":
     import argparse
+    import getpass
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
     parser = argparse.ArgumentParser(description="Fetch Pixiv OAuth refresh token")
-    parser.add_argument("--username", "-u", required=True)
-    parser.add_argument("--password", "-p", required=True)
-    parser.add_argument("--no-headless", action="store_true", help="Show browser window")
+    parser.add_argument("--username", "-u", help="Pixiv account email or username")
+    parser.add_argument("--password", "-p", help="Pixiv account password")
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="Run without showing the browser window",
+    )
+    parser.add_argument(
+        "--no-headless",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--capture-timeout",
+        type=int,
+        default=DEFAULT_CAPTURE_TIMEOUT,
+        help="Seconds to wait for the OAuth callback before manual fallback",
+    )
+    parser.add_argument(
+        "--input-timeout",
+        type=int,
+        default=DEFAULT_INPUT_TIMEOUT,
+        help="Milliseconds to wait for each login input selector",
+    )
+    parser.add_argument(
+        "--navigation-timeout",
+        type=int,
+        default=DEFAULT_NAVIGATION_TIMEOUT,
+        help="Milliseconds to wait for Pixiv login page navigation",
+    )
+    parser.add_argument(
+        "--request-timeout",
+        type=float,
+        default=DEFAULT_REQUEST_TIMEOUT,
+        help="Seconds to wait for the Pixiv token HTTP request",
+    )
+    parser.add_argument(
+        "--typing-delay",
+        type=float,
+        default=DEFAULT_TYPING_DELAY,
+        help="Seconds to wait between typed characters",
+    )
     args = parser.parse_args()
 
-    fetcher = PixivTokenFetcher(args.username, args.password, headless=not args.no_headless)
+    username = args.username
+    password = args.password
+    if not username:
+        if not sys.stdin.isatty():
+            parser.error("--username is required when stdin is not interactive")
+        try:
+            username = input("Pixiv username/email: ").strip()
+        except EOFError:
+            parser.error("--username is required when stdin cannot be read")
+    if not password:
+        if not sys.stdin.isatty():
+            parser.error("--password is required when stdin is not interactive")
+        try:
+            password = getpass.getpass("Pixiv password: ")
+        except EOFError:
+            parser.error("--password is required when stdin cannot be read")
+
+    if not username:
+        parser.error("username must not be empty")
+    if not password:
+        parser.error("password must not be empty")
+
+    fetcher = PixivTokenFetcher(
+        username,
+        password,
+        headless=args.headless and not args.no_headless,
+        capture_timeout=args.capture_timeout,
+        input_timeout=args.input_timeout,
+        navigation_timeout=args.navigation_timeout,
+        request_timeout=args.request_timeout,
+        typing_delay=args.typing_delay,
+    )
     code = fetcher.fetch_code()
     if code:
-        token_info = fetcher.exchange_token(code)
+        try:
+            token_info = fetcher.exchange_token(code)
+        except PixivTokenError as exc:
+            logger.error("Failed to exchange token: %s", exc)
+            sys.exit(1)
         print(f"Access Token: {token_info.get('access_token')}")
         print(f"Refresh Token: {token_info.get('refresh_token')}")
     else:
-        print("Failed to retrieve authorization code.")
+        logger.error("Failed to retrieve authorization code.")
+        sys.exit(1)


### PR DESCRIPTION
> 你好作者大大，因为之前一直用的第三方api来获取p站图片，但是近期站点挂掉了，我主要是用来接在astrbot里面让机器人发图片的，我在网上找了一下，最开始是下载找到了 ["pixivpy-async"](https://github.com/mikubill/pixivpy-async) 但是看到里面说要获取 `refresh token` 于是找到了贵项目，一开始运行的时候出现了一些报错提示，问了gpt后发现是没有安装 `Playwright 自带 Chromium` 然后我就让gpt和claude帮我进行修改，让他更便于操作，经测试没发现问题，以下是主要修改的地方，希望能够同意我的pr,如果有不合理的地方请大大指正，我一定严肃学习

# 修复：适配当前 Pixiv 登录流程下的 OAuth 回调捕获

主仓库目前在新版 Pixiv 上拿不到 `code`，原因是回调不再稳定地走 `Network.requestWillBeSent`（Pixiv 改成了 `location.assign` / `history.pushState` 等浏览器内导航）。本 PR 主要做了以下改动：

## 核心修复

- **多路捕获授权码**：同时监听 CDP 网络/导航事件、Playwright `request` / `response` / `framenavigated` 事件，以及注入页面的 JS 脚本（监控 `location`、`history`、点击、`MutationObserver`），任一通道捕到都立即返回。
- **手动粘贴兜底**：自动捕获失败时，在终端提示用户粘贴完整回调 URL 或原始 `code`。
- **登录页 `goto` 加超时容错**：慢网络下不直接抛 `TimeoutError`。

## 新增能力

- 新增 `refresh_token()` 方法：可用已有 refresh token 刷新 access token，避免重跑登录。
- **系统浏览器优先**：Windows 上优先检测 Chrome / Edge，找不到再用 Playwright 自带 Chromium。
- **token 交换失败时询问重试**：Pixiv OAuth 端点 `oauth.secure.pixiv.net` 偶发返回 TLS 告警，简单重试通常即可成功；不再立即退出导致用户重走整个 Playwright 登录。
- **交互式输入**：`--username` / `--password` 不再强制必填，缺失时在终端 prompt（密码不回显）；默认弹出“是否打开浏览器窗口？(Y/n)”。

## 行为变更

- 默认改为可见浏览器模式（`headless=False`）：Pixiv 现在常需要人工过人机验证，无头会卡死。`--headless` 仍可显式打开无头；旧的 `--no-headless` 作为隐藏别名保留兼容。
- token 请求加上了 `timeout=30` 和明确的错误异常 `PixivTokenError`。

## 不变

- 公开 API 兼容：`PixivTokenFetcher(username, password, headless)` 签名未变；`exchange_token(code)` 行为不变。
- 不引入新依赖。